### PR TITLE
Support mixed graphic adapters

### DIFF
--- a/src/gpu/engine_info.cpp
+++ b/src/gpu/engine_info.cpp
@@ -77,7 +77,7 @@ int get_gpu_device_id()
     }
 #elif defined(__linux__)
     {
-        std::string dev_base{ "/sys/class/graphics/fb" };
+        std::string dev_base{ "/sys/class/drm/card" };
         int dev_idx = 0;
         for (; dev_idx < 32; dev_idx++)
         {


### PR DESCRIPTION
There are two graphics adapters. Only one of them shows up as sys/class/graphics/fb. It's an AMD. The modified code helped to detect Intel GPU on the second adapter. All tests passed afterwards.