### PR TITLE
Fixed include directive. Header file in the same directory.

### DIFF
--- a/api/CPP/tensor.hpp
+++ b/api/CPP/tensor.hpp
@@ -19,7 +19,7 @@
 #include "cldnn_defs.h"
 #include "compounds.h"
 #include "meta_utils.hpp"
-#include "api/CPP/serialization_helper.h"
+#include "serialization_helper.h"
 
 #include <map>
 #include <list>


### PR DESCRIPTION
Requested fix from NervanaGraph team.
nGraph application can't build due to this include directive.