### PR TITLE
Fixes for NGraph

### DIFF
--- a/src/graph_optimizer/eltwise_shrinking.cpp
+++ b/src/graph_optimizer/eltwise_shrinking.cpp
@@ -62,6 +62,13 @@ void eltwise_shrinking::run(program_impl& p)
                     }
 
                     auto weights_node_ptr = p.get_node_ptr(conv->weights[0]);
+                    // make sure that eltwise node is not filter for convolution
+                    if (weights_node_ptr->id() == node->id())
+                    {
+                        can_shrink = false;
+                        break;
+                    }
+
                     auto filter_size = weights_node_ptr->get_output_layout().size;
                     // make sure this is conv 1x1
                     if (filter_size.spatial[0] != 1 || filter_size.spatial[1] != 1)

--- a/src/graph_optimizer/prepare_padding.cpp
+++ b/src/graph_optimizer/prepare_padding.cpp
@@ -20,6 +20,7 @@
 #include "program_node.h"
 #include "pass_manager.h"
 #include "convolution_inst.h"
+#include "custom_gpu_primitive_inst.h"
 #include "sliding_window_utils.h"
 
 using namespace cldnn;
@@ -111,7 +112,8 @@ void prepare_padding::run(program_impl& p)
         }
 
         // We shoudn't apply any padding to nodes which are marked as outputs
-        if (conv_input_node.is_output())
+        // or nodes which are custom primitives
+        if (conv_input_node.is_output() || conv_input_node.is_type<custom_gpu_primitive>())
             continue;
 
         // Calculating input padding needed for convolution


### PR DESCRIPTION
Two fixes for NGraph:
1. Disabled prepare_padding optimization for custom primitives. - custom primitives shouldn't be modified by some optimizations.
2. Do not run eltwise_shrinking when eltwise node is filter for convolution. - this optimization should only be done if eltwise is input to convolution.