### PR TITLE
Added get_or_create function for program_node parameter. Needed for d…

### DIFF
--- a/src/include/program_impl.h
+++ b/src/include/program_impl.h
@@ -124,9 +124,10 @@ public:
     std::shared_ptr<program_node> get_node_ptr(const primitive_id& prim) const { return nodes_map.at(prim); }
     void dump_memory_pool() const;
 
-    //returns already existing program_node for given primitive 'prim' (lookup in 'nodes_map')
+    //returns already existing program_node for given primitive 'prim' or program_node 'node' (lookup in 'nodes_map')
     //if it was previously created, otherwise creates and then returns program_node
     program_node& get_or_create(std::shared_ptr<primitive> prim);
+    program_node& get_or_create(std::shared_ptr<program_node> node);
 
     // Inserts given program_node 'node' as an intermediate node between 'next' and it's
     //  dependency at 'prev_idx' index.

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -211,7 +211,7 @@ void program_impl::prepare_nodes(std::set<std::shared_ptr<program_node>>const &n
         }
         else
         {
-            get_or_create(itr->desc);
+            get_or_create(itr);
         }
     }
     for (const auto& node : nodes_map)

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -769,6 +769,22 @@ program_node& program_impl::get_or_create(std::shared_ptr<primitive> prim)
         return *itr->second;
 
     auto new_node = prim->get_type()->create_node(*this, prim);
+
+    nodes_map.insert(itr, { prim->get_id(), new_node });
+    return *new_node;
+}
+
+program_node& program_impl::get_or_create(std::shared_ptr<program_node> node)
+{
+    std::shared_ptr<primitive> prim = node->desc;
+    auto itr = nodes_map.lower_bound(prim->get_id());
+    if (itr != nodes_map.end() && itr->first == prim->get_id())
+        return *itr->second;
+
+    auto new_node = prim->get_type()->create_node(*this, prim);
+    // Need to copy values specific for node
+    new_node->set_fused_activation(node->get_fused_activation_func(), node->get_fused_activation_params());
+
     nodes_map.insert(itr, { prim->get_id(), new_node });
     return *new_node;
 }


### PR DESCRIPTION
…uplicating nodes for internal topologies.
This fixes issue when "propagate constants" optimization is executed on nodes, which were previously fused with activation.