### PR TITLE
Remove const off a pointer

### DIFF
--- a/src/include/generic_layer.hpp
+++ b/src/include/generic_layer.hpp
@@ -61,7 +61,7 @@ struct generic_layer : public primitive_base<generic_layer, CLDNN_PRIMITIVE_DESC
     generic_layer(const dto* dto)
         : primitive_base(dto)
         , output_layout(dto->output_layout)
-        , generic_params(*static_cast<const kernel_selector::generic_kernel_params* const>(dto->generic_params))
+        , generic_params(*static_cast<const kernel_selector::generic_kernel_params*>(dto->generic_params))
     {
     }
 


### PR DESCRIPTION
Compiling with GCC 8.3.1 on CentOS7 gives the following warning ( error here as we use -Werror ):

./src/include/generic_layer.hpp:64:111: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
         , generic_params(*static_cast<const kernel_selector::generic_kernel_params* const>(dto->generic_params))

Removed the const off the pointer to fix this.