### PR TITLE
Two warning compilation fixes

### DIFF
--- a/common/khronos_ocl_clhpp/cl2.hpp
+++ b/common/khronos_ocl_clhpp/cl2.hpp
@@ -2700,7 +2700,7 @@ public:
                     error = platforms[i].getDevices(type, &devices);
 
 #if defined(CL_HPP_ENABLE_EXCEPTIONS)
-                } catch (Error) {}
+                } catch (Error&) {}
     // Catch if exceptions are enabled as we don't want to exit if first platform has no devices of type
     // We do error checking next anyway, and can throw there if needed
 #endif

--- a/src/include/generic_layer.hpp
+++ b/src/include/generic_layer.hpp
@@ -61,7 +61,7 @@ struct generic_layer : public primitive_base<generic_layer, CLDNN_PRIMITIVE_DESC
     generic_layer(const dto* dto)
         : primitive_base(dto)
         , output_layout(dto->output_layout)
-        , generic_params(*static_cast<const kernel_selector::generic_kernel_params* const>(dto->generic_params))
+        , generic_params(*static_cast<const kernel_selector::generic_kernel_params*>(dto->generic_params))
     {
     }
 


### PR DESCRIPTION
This PR aims to fix two warnings:

* ./src/include/generic_layer.hpp:64:111: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
* ./common/khronos_ocl_clhpp/cl2.hpp:2703:26: error: catching polymorphic type ‘class cl::Error’ by value [-Werror=catch-value=]


